### PR TITLE
Add unique_with argument to sluggable field

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -21,15 +21,14 @@ a specific user is changing his username: we want a permanent redirection
 between the old username and the new one.
 
 
-In ``models.py``, we will define a decider model which will store all usernames::
+In ``models.py``, we will define a slugs model which will store all usernames::
 
     # users/models.py
     from sluggable.models import Slug
 
 
     class UserSlug(Slug):
-        class Meta:
-            abstract = False
+        pass
 
 In the case of our ``User`` class the slug is basically the username of the user,
 so we will change the type of the ``username`` field.
@@ -37,11 +36,12 @@ so we will change the type of the ``username`` field.
 ::
 
     # users/models.py
+    from django.contrib.contenttypes import generic
     from sluggable.fields import SluggableField
 
-
     class User(models.Model):
-        username = SluggableField(decider=UserSlug)
+        username = SluggableField(unique=True)
+        slugs = generic.GenericRelation(UserSlug)
 
         def __unicode__(self):
             return self.username
@@ -215,6 +215,21 @@ But we have to rewrite our ``urls.py`` file to use `django-multiurl`_::
     )
 
 .. image:: http://ragefaces.s3.amazonaws.com/5041ed6dae7c704f08000007/85cbfbcb8f496826ca8867bd28e0d3b9.png
+
+
+Unique with
+-----------
+
+You can specify a ``unique_with`` argument to ``SluggableField`` in order to
+restrict slugs to uniqueness only per the fields specified. For example::
+
+    class PostSlug(Slug):
+        pass
+
+    class Post(models.Model):
+        category = models.CharField(max_length=100)
+        slug = SluggableField(unique_with=('category',))
+        slugs = generic.GenericRelation(PostSlug)
 
 
 Hidden features

--- a/sluggable/models.py
+++ b/sluggable/models.py
@@ -7,7 +7,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.utils.encoding import python_2_unicode_compatible
 
 
-from .utils import get_obj_id, generate_unique_slug
+from .utils import get_obj_id
 
 
 class SlugQuerySet(QuerySet):
@@ -76,13 +76,6 @@ class SlugManager(models.Manager):
 
         return True
 
-    def generate_unique_slug(self, instance, slug, max_length, index_sep):
-
-        qs = self.filter_by_obj(instance, exclude=True)
-
-        return generate_unique_slug(qs, instance, slug, max_length,
-                                    'slug', index_sep)
-
     def update_slug(self, instance, slug,
                     erase_redirects=False,
                     created=False):
@@ -135,8 +128,7 @@ class Slug(models.Model):
 
     slug = models.CharField(max_length=255,
                             verbose_name=_('URL'),
-                            db_index=True,
-                            unique=True)
+                            db_index=True)
     redirect = models.BooleanField(default=False,
                                    verbose_name=_('Redirection'))
 

--- a/sluggable/tests/models.py
+++ b/sluggable/tests/models.py
@@ -2,30 +2,43 @@ from __future__ import unicode_literals
 
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
+from django.contrib.contenttypes import generic
 
 from sluggable.models import Slug
 from sluggable.fields import SluggableField
 
 
 class PollSlug(Slug):
-    class Meta:
-        abstract = False
-
+    pass
 
 @python_2_unicode_compatible
 class Poll(models.Model):
     question = models.CharField(max_length=200)
     pub_date = models.DateTimeField('date published', auto_now_add=True)
-    slug = SluggableField(populate_from='question', decider=PollSlug)
+    slug = SluggableField(populate_from='question', unique=True)
+    slugs = generic.GenericRelation(PollSlug)
 
     def __str__(self):
         return self.question
 
 
 class UserSlug(Slug):
-    class Meta:
-        abstract = False
-
+    pass
 
 class User(models.Model):
-    username = SluggableField(decider=UserSlug, unique=True)
+    username = SluggableField(unique=True)
+    slugs = generic.GenericRelation(UserSlug)
+
+
+class PostSlug(Slug):
+    pass
+
+class Post(models.Model):
+    user = models.ForeignKey(User)
+    slug = SluggableField(unique_with='user')
+    slugs = generic.GenericRelation(PostSlug)
+
+class DayPost(models.Model):
+    date = models.DateField()
+    slug = SluggableField(unique_with='date')
+    slugs = generic.GenericRelation(PostSlug)

--- a/sluggable/tests/models.py
+++ b/sluggable/tests/models.py
@@ -42,3 +42,9 @@ class DayPost(models.Model):
     date = models.DateField()
     slug = SluggableField(unique_with='date')
     slugs = generic.GenericRelation(PostSlug)
+
+class WordPost(models.Model):
+    user = models.ForeignKey(User)
+    word = models.CharField(max_length=50, blank=True)
+    slug = SluggableField(unique_with=('user', 'word'))
+    slugs = generic.GenericRelation(PostSlug)

--- a/sluggable/tests/tests.py
+++ b/sluggable/tests/tests.py
@@ -4,7 +4,7 @@ from datetime import date
 
 from django.test import TestCase
 
-from .models import Poll, PollSlug, UserSlug, User, Post, DayPost, PostSlug
+from .models import Poll, PollSlug, UserSlug, User, Post, DayPost, WordPost, PostSlug
 
 
 class SluggableTests(TestCase):
@@ -174,3 +174,18 @@ class SluggableTests(TestCase):
 
     def test_unique_with_date(self):
         self._unique_with(DayPost, 'date', date(2014, 1, 1), date(2014, 2, 1))
+
+    def test_unique_with_blank_word(self):
+        user = User.objects.create(username='matthew')
+
+        post1 = WordPost.objects.create(user=user, word='word', slug='a-slug')
+        post2 = WordPost.objects.create(user=user, word='word', slug='a-slug')
+        post3 = WordPost.objects.create(user=user, word='', slug='a-slug')
+        post4 = WordPost.objects.create(user=user, word='', slug='a-slug')
+
+        self.assertEquals(PostSlug.objects.count(), 4)
+
+        self.assertEquals(post1.slug, 'a-slug')
+        self.assertEquals(post2.slug, 'a-slug-2')
+        self.assertEquals(post3.slug, 'a-slug')
+        self.assertEquals(post4.slug, 'a-slug-2')

--- a/sluggable/utils.py
+++ b/sluggable/utils.py
@@ -100,9 +100,7 @@ def get_uniqueness_lookups(field, instance, unique_with):
                              % (instance._meta.object_name, field_name))
 
         value = getattr(instance, field_name)
-        if not value:
-            if other_field.blank:
-                break
+        if not value and not other_field.blank:
             raise ValueError('Could not check uniqueness of %s.%s with'
                              ' respect to %s.%s because the latter is empty.'
                              ' Please ensure that "%s" is declared *after*'

--- a/sluggable/utils.py
+++ b/sluggable/utils.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from django.db import models
+from django.db.models.fields import FieldDoesNotExist, DateField
 
 
 def get_obj_id(obj):
@@ -30,8 +31,7 @@ def crop_slug(slug, max_length):
     return slug
 
 
-def generate_unique_slug(qs, instance, slug, max_length,
-                         field_name, index_sep):
+def generate_unique_slug(field, instance, slug, manager):
     """
     Generates unique slug by adding a number to given value until no model
     instance can be found with such slug. If ``unique_with`` (a tuple of field
@@ -39,14 +39,20 @@ def generate_unique_slug(qs, instance, slug, max_length,
     in the query when looking for a "rival" model instance.
     """
 
-    original_slug = slug = crop_slug(slug, max_length)
+    original_slug = slug = crop_slug(slug, field.max_length)
+
+    default_lookups = tuple(get_uniqueness_lookups(field, instance, field.unique_with))
 
     index = 1
+
+    if not manager:
+        manager = field.model._default_manager
 
     # keep changing the slug until it is unique
     while True:
         # find instances with same slug
-        rivals = qs.filter(**{field_name: slug}).exclude(pk=instance.pk)
+        lookups = dict(default_lookups, slugs__slug=slug)
+        rivals = manager.filter(**lookups).exclude(pk=instance.pk)
 
         if not rivals:
             # the slug is unique, no model uses it
@@ -56,16 +62,82 @@ def generate_unique_slug(qs, instance, slug, max_length,
         index += 1
 
         # ensure the resulting string is not too long
-        tail_length = len(index_sep) + len(str(index))
+        tail_length = len(field.index_sep) + len(str(index))
         combined_length = len(original_slug) + tail_length
-        if max_length < combined_length:
-            original_slug = original_slug[:max_length - tail_length]
+        if field.max_length < combined_length:
+            original_slug = original_slug[:field.max_length - tail_length]
 
         # re-generate the slug
         data = dict(slug=original_slug,
-                    sep=index_sep,
+                    sep=field.index_sep,
                     index=index)
 
         slug = '%(slug)s%(sep)s%(index)d' % data
 
     return slug
+
+def get_uniqueness_lookups(field, instance, unique_with):
+    """
+    Returns a dict'able tuple of lookups to ensure uniqueness of a slug.
+    """
+    for original_lookup_name in unique_with:
+        if '__' in original_lookup_name:
+            field_name, inner_lookup = original_lookup_name.split('__', 1)
+        else:
+            field_name, inner_lookup = original_lookup_name, None
+
+        try:
+            other_field = instance._meta.get_field(field_name)
+        except FieldDoesNotExist:
+            raise ValueError('Could not find attribute %s.%s referenced'
+                             ' by %s.%s (see constraint `unique_with`)'
+                             % (instance._meta.object_name, field_name,
+                                instance._meta.object_name, field.name))
+
+        if field == other_field:
+            raise ValueError('Attribute %s.%s references itself in `unique_with`.'
+                             ' Please use "unique=True" for this case.'
+                             % (instance._meta.object_name, field_name))
+
+        value = getattr(instance, field_name)
+        if not value:
+            if other_field.blank:
+                break
+            raise ValueError('Could not check uniqueness of %s.%s with'
+                             ' respect to %s.%s because the latter is empty.'
+                             ' Please ensure that "%s" is declared *after*'
+                             ' all fields listed in unique_with.'
+                             % (instance._meta.object_name, field.name,
+                                instance._meta.object_name, field_name,
+                                field.name))
+        if isinstance(other_field, DateField):    # DateTimeField is a DateField subclass
+            inner_lookup = inner_lookup or 'day'
+
+            if '__' in inner_lookup:
+                raise ValueError('The `unique_with` constraint in %s.%s'
+                                 ' is set to "%s", but AutoSlugField only'
+                                 ' accepts one level of nesting for dates'
+                                 ' (e.g. "date__month").'
+                                 % (instance._meta.object_name, field.name,
+                                    original_lookup_name))
+
+            parts = ['year', 'month', 'day']
+            try:
+                granularity = parts.index(inner_lookup) + 1
+            except ValueError:
+                raise ValueError('expected one of %s, got "%s" in "%s"'
+                                    % (parts, inner_lookup, original_lookup_name))
+            else:
+                for part in parts[:granularity]:
+                    lookup = '%s__%s' % (field_name, part)
+                    yield lookup, getattr(value, part)
+        else:
+            # TODO: this part should be documented as it involves recursion
+            if inner_lookup:
+                if not hasattr(value, '_meta'):
+                    raise ValueError('Could not resolve lookup "%s" in `unique_with` of %s.%s'
+                                     % (original_lookup_name, instance._meta.object_name, field.name))
+                for inner_name, inner_value in get_uniqueness_lookups(field, value, [inner_lookup]):
+                    yield original_lookup_name, inner_value
+            else:
+                yield field_name, value


### PR DESCRIPTION
This pull request takes some more code from https://pypi.python.org/pypi/django-autoslug to implement the unique_with argument, allowing  slugs to be unique only within the other fields specified. For example, `slug = SluggableField(unique_with=('category',))` would allow slugs to be the same in different categories, but unique within one category.

In order for this to work, it switches from a decider argument to a slugs generic relation, I don't think that has any side effects, but could be wrong.

It also (unlike django-autoslug) still requires uniqueness lookups when a uniqueness field is empty. This is because you may well have a uniqueness tuple in which one is empty but still require uniqueness (e.g. section slugs in a hierarchy with uniqueness on parent).
